### PR TITLE
Implement Decomposition MonteCarlo MM

### DIFF
--- a/DecompositionMonteCarloMM_method.tpl
+++ b/DecompositionMonteCarloMM_method.tpl
@@ -1,13 +1,13 @@
-sqMMDecompositionMonteCarloMM(
-    Symbol(),
-    OP_BUY,       // 注文種別はロット計算に影響しないためダミーで可
-    Ask,          // 価格もロット計算に未使用。将来互換のため渡す
-    0.0,          // SL 未使用
-    mmBaseLot,
-    mmMaxDrawdown,
-    mmDecimals,
-    mmDebugLogs,
-    mmAuditCSV,
-    mmEnforceMaxLot,
-    mmMaxLotCap,
-    mmStep)
+<@compress_single_line>sqMMDecompositionMonteCarloMM(
+            <@printSymbol block />, 
+            <@printOrderType block orderType directionParamName />, 
+            openPrice, 
+            sl, 
+            mmBaseLot, 
+            mmMaxDrawdown, 
+            mmDecimals, 
+            mmDebugLogs, 
+            mmAuditCSV, 
+            mmEnforceMaxLot, 
+            mmMaxLotCap, 
+            mmStep)</@compress_single_line>


### PR DESCRIPTION
## Summary
- add per-symbol state and order history handling for Decomposition MonteCarlo money management
- expose sqMMDecompositionMonteCarloMM for StrategyQuant templates
- update method template to invoke new logic with proper macros

## Testing
- `echo 'no tests'`


------
https://chatgpt.com/codex/tasks/task_e_68b2d97f4a6c83279514f9ea1729792f