### PR TITLE
Fix Decomposition MonteCarlo MM sequence handling

### DIFF
--- a/DecompositionMonteCarloMM_class.tpl
+++ b/DecompositionMonteCarloMM_class.tpl
@@ -91,7 +91,7 @@ int DMC_getStateIndex(string symbol, double baseLot, double step, int decimals)
    return idx;
 }
 
-void DMC_applyLastClosedOrder(string symbol, DecompositionMonteCarloMM_State &st)
+void DMC_applyLastClosedOrder(string symbol, int magicNumber, DecompositionMonteCarloMM_State &st)
 {
    int total = OrdersHistoryTotal();
    for (int i = total - 1; i >= 0; i--)
@@ -99,6 +99,8 @@ void DMC_applyLastClosedOrder(string symbol, DecompositionMonteCarloMM_State &st
       if (!OrderSelect(i, SELECT_BY_POS, MODE_HISTORY))
          continue;
       if (OrderSymbol() != symbol)
+         continue;
+      if (OrderMagicNumber() != magicNumber)
          continue;
       if (OrderOpenTime() == st.prevOpenTime && OrderCloseTime() == st.prevCloseTime)
          break; // 既に処理済み
@@ -422,7 +424,8 @@ double DMC_updateAndCalcLot(DecompositionMonteCarloMM_State &st, bool isWin)
 double sqMMDecompositionMonteCarloMM(string symbol, ENUM_ORDER_TYPE orderType, double price, double sl,
                                      double baseLot, double maxDrawdown, int decimals,
                                      bool debugLogs, bool auditCSV,
-                                     bool enforceMaxLot, double maxLotCap, double step)
+                                     bool enforceMaxLot, double maxLotCap, double step,
+                                     int magicNumber)
 {
    if (UseMoneyManagement == false)
       return baseLot;
@@ -448,7 +451,7 @@ double sqMMDecompositionMonteCarloMM(string symbol, ENUM_ORDER_TYPE orderType, d
    }
 
    // 最新のクローズドオーダーを反映
-   DMC_applyLastClosedOrder(correctedSymbol, st);
+   DMC_applyLastClosedOrder(correctedSymbol, magicNumber, st);
 
    int betUnits = DMC_getBetUnits(st.sequence);
    int mult     = DMC_getMultiplier(st.winStreak);

--- a/DecompositionMonteCarloMM_method.tpl
+++ b/DecompositionMonteCarloMM_method.tpl
@@ -9,5 +9,6 @@
             mmDebugLogs, 
             mmAuditCSV, 
             mmEnforceMaxLot, 
-            mmMaxLotCap, 
-            mmStep)</@compress_single_line>
+            mmMaxLotCap,
+            mmStep,
+            MagicNumber)</@compress_single_line>


### PR DESCRIPTION
## Summary
- filter historical orders by magic number in Decomposition MonteCarlo MM
- pass magic number through money management template to maintain state

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68b2f12543688327ac7441935eab3365