### PR TITLE
Tpl 数列処理を Java 実装に合わせて修正

### DIFF
--- a/DecompositionMonteCarloMM_class.tpl
+++ b/DecompositionMonteCarloMM_class.tpl
@@ -318,7 +318,7 @@ void DMC_updateSequence_RDR(DecompositionMonteCarloMM_State &st, bool isWin)
    }
 
    int leftBefore  = st.sequence[0];
-   int rightBefore = st.sequence[n - 1];
+   int rightBefore = (n >= 2 ? st.sequence[n - 1] : st.sequence[0]);
 
    if (isWin)
    {
@@ -367,7 +367,7 @@ void DMC_updateSequence_RDR(DecompositionMonteCarloMM_State &st, bool isWin)
          n = 2;
       }
 
-      // 5) A/B平均化（左0ならA、左>0ならB）
+      // 4) A/B平均化（左0ならA、左>0ならB）
       if (st.sequence[0] == 0) DMC_averageA_index1(st.sequence);
       else                     DMC_averageB_index1(st.sequence);
    }


### PR DESCRIPTION
## 概要
- DMC_updateSequence_RDR の右端取得を Java 実装と同等になるよう修正
- 勝利時の A/B 平均化ステップ番号を整理

## テスト
- `javac DecompositionMonteCarloMM.java` (依存ライブラリ不足でエラーになるが実行を確認)

------
https://chatgpt.com/codex/tasks/task_e_68b2f87ae97c8327a22758fe30078b32