### PR TITLE
Javaとの数列処理差異を解消

### DIFF
--- a/DecompositionMonteCarloMM_class.tpl
+++ b/DecompositionMonteCarloMM_class.tpl
@@ -261,15 +261,15 @@ void DMC_zeroGeneration(int &seq[])
    int redistribute = seq[0];
    seq[0] = 0;
 
-   int S = 0;
+   long S = 0;
    for (int i=0; i<n; i++) S += seq[i];
 
    int subCount = n - 1;
    if (subCount <= 0) subCount = 1;
 
-   int totalInc = S + redistribute;
-   int check    = totalInc % subCount;
-   int avg      = totalInc / subCount;
+   long totalInc = S + redistribute;
+   int  check    = (int)(totalInc % subCount);
+   int  avg      = (int)(totalInc / subCount);
    if (redistribute < subCount)
    {
       // 先頭の値を index1 に集約
@@ -395,7 +395,7 @@ void DMC_updateSequence_RDR(DecompositionMonteCarloMM_State &st, bool isWin)
       n = ArraySize(st.sequence);
       if (n > 0 && st.sequence[0] > 0 && st.stock > 0)
       {
-         int use = (st.sequence[0] <= st.stock ? st.sequence[0] : st.stock);
+         int use = MathMin(st.sequence[0], st.stock);
          st.sequence[0] -= use;
          st.stock       -= use;
       }


### PR DESCRIPTION
## 概要
- 数列処理で使用する変数を`long`に変更し、オーバーフローを防止
- ストック消費に`MathMin`を用いてJavaロジックと完全一致化

## テスト
- `javac DecompositionMonteCarloMM.java` (依存ライブラリ欠如のため失敗)

------
https://chatgpt.com/codex/tasks/task_e_68b305baff2c8327a406bcbcfb12a198