### PR TITLE
Fix variable template macros for DecompositionMonteCarloMM

### DIFF
--- a/DecompositionMonteCarloMM_variables.tpl
+++ b/DecompositionMonteCarloMM_variables.tpl
@@ -1,3 +1,12 @@
+<#--
+  SQX のテンプレート処理では `printMMVariableNumber` や `printMMVariableBool`
+  マクロが定義されていない場合、null 参照エラーとなってしまう。
+  ここでは簡易的なフォールバックマクロを用意し、値が未定義でも
+  テンプレート展開が失敗しないようにする。
+-->
+<#macro printMMVariableNumber v>${v?default(0)}</#macro>
+<#macro printMMVariableBool v>${v?default(false)}</#macro>
+
 <#-- Inputs for DecompositionMonteCarlo Money Management -->
 input string smm = "----------- Money Management - DecompositionMonteCarloMM -----------";
 input bool   UseMoneyManagement = true;
@@ -8,4 +17,4 @@ input bool   mmDebugLogs     = <@printMMVariableBool "#DebugLogs#" />;
 input bool   mmAuditCSV      = <@printMMVariableBool "#AuditCSV#" />;
 input bool   mmEnforceMaxLot = <@printMMVariableBool "#EnforceMaxLot#" />;
 input double mmMaxLotCap     = <@printMMVariableNumber "#MaxLotCap#" />;
-input double mmStep          = ${orderSizeStep};
+input double mmStep          = ${orderSizeStep!0};


### PR DESCRIPTION
## Summary
- Avoid null reference errors in DecompositionMonteCarloMM variables template by providing fallback macros for numeric and boolean parameters
- Default `orderSizeStep` to 0 when unspecified

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68b340fec3c4832798b1ff310edf0e5d