### PR TITLE
Fix MM variable placeholders

### DIFF
--- a/DecompositionMonteCarloMM_variables.tpl
+++ b/DecompositionMonteCarloMM_variables.tpl
@@ -10,11 +10,11 @@
 <#-- Inputs for DecompositionMonteCarlo Money Management -->
 input string smm = "----------- Money Management - DecompositionMonteCarloMM -----------";
 input bool   UseMoneyManagement = true;
-input double mmBaseLot       = <@printMMVariableNumber "#BaseLot#" />;
-input double mmMaxDrawdown   = <@printMMVariableNumber "#MaxDrawdown#" />;
-input int    mmDecimals      = <@printMMVariableNumber "#Decimals#" />;
-input bool   mmDebugLogs     = <@printMMVariableBool "#DebugLogs#" />;
-input bool   mmAuditCSV      = <@printMMVariableBool "#AuditCSV#" />;
-input bool   mmEnforceMaxLot = <@printMMVariableBool "#EnforceMaxLot#" />;
-input double mmMaxLotCap     = <@printMMVariableNumber "#MaxLotCap#" />;
+input double mmBaseLot       = <@printMMVariableNumber BaseLot/>;
+input double mmMaxDrawdown   = <@printMMVariableNumber MaxDrawdown/>;
+input int    mmDecimals      = <@printMMVariableNumber Decimals/>;
+input bool   mmDebugLogs     = <@printMMVariableBool DebugLogs/>;
+input bool   mmAuditCSV      = <@printMMVariableBool AuditCSV/>;
+input bool   mmEnforceMaxLot = <@printMMVariableBool EnforceMaxLot/>;
+input double mmMaxLotCap     = <@printMMVariableNumber MaxLotCap/>;
 input double mmStep          = ${orderSizeStep!0};

--- a/New.mq4
+++ b/New.mq4
@@ -44,13 +44,13 @@ extern double StopLoss1 = 50;
 //+------------------------------------------------------------------+
 input string smm = "----------- Money Management - DecompositionMonteCarloMM -----------";
 input bool   UseMoneyManagement = true;
-input double mmBaseLot       = #BaseLot#;
-input double mmMaxDrawdown   = #MaxDrawdown#;
-input int    mmDecimals      = #Decimals#;
-input bool   mmDebugLogs     = #DebugLogs#;
-input bool   mmAuditCSV      = #AuditCSV#;
-input bool   mmEnforceMaxLot = #EnforceMaxLot#;
-input double mmMaxLotCap     = #MaxLotCap#;
+input double mmBaseLot       = 0.01;
+input double mmMaxDrawdown   = 100.0;
+input int    mmDecimals      = 2;
+input bool   mmDebugLogs     = true;
+input bool   mmAuditCSV      = false;
+input bool   mmEnforceMaxLot = false;
+input double mmMaxLotCap     = 1.50;
 input double mmStep          = 0.01;
 extern double InitialCapital = 10000; //InitialCapital (0 means whole account balance). Used in some MM methods.
 


### PR DESCRIPTION
## Summary
- fix DecompositionMonteCarloMM variables template to emit actual values instead of `#` placeholders
- update generated New.mq4 inputs to valid defaults

## Testing
- `mql4 New.mq4` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3445302448327bb4f5a089e1e85b8