### PR TITLE
Fix Monte Carlo MM history tracking and lot sizing

### DIFF
--- a/DecompositionMonteCarloMM_variables.tpl
+++ b/DecompositionMonteCarloMM_variables.tpl
@@ -12,6 +12,8 @@ int    DMCMM_consecWins           = 0;   // Consecutive win counter
 double DMCMM_cycleProfit          = 0.0; // Accumulated profit within the current cycle
 double DMCMM_curBet               = 0.0; // Current bet amount (lots)
 int    DMCMM_processedOrdersCount = 0;   // Processed history orders counter
+datetime DMCMM_lastCloseTime      = 0;   // Last processed order close time
+int      DMCMM_lastCloseTicket    = -1;  // Last processed order ticket (for tie-break)
 bool   DMCMM_initialized          = false;
 
 // ===== Broker constraints =====


### PR DESCRIPTION
## Summary
- track the last processed close time and ticket so that newly closed orders update the Monte Carlo sequence
- read the executed lot size from the closed order and round up to the broker lot step to prevent the bet amount from stagnating
- reset historical cursors on reinitialization to keep the money management state in sync

## Testing
- not run (tests not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cb85b9bb288327af1aa122c9257654