### PR TITLE
Fix lot rounding to respect base lot

### DIFF
--- a/DecompositionMonteCarloMM_variables.tpl
+++ b/DecompositionMonteCarloMM_variables.tpl
@@ -12,7 +12,6 @@ int    DMCMM_consecWins           = 0;   // Consecutive win counter
 double DMCMM_cycleProfit          = 0.0; // Accumulated profit within the current cycle
 double DMCMM_curBet               = 0.0; // Current bet amount (lots)
 double DMCMM_lastExecutedBet      = 0.0; // Last theoretical bet used for closed order evaluation
-double DMCMM_stepRatio            = 1.0; // Scaling ratio between Java step and broker lot step
 int    DMCMM_processedOrdersCount = 0;   // Processed history orders counter
 datetime DMCMM_lastCloseTime      = 0;   // Last processed order close time
 int      DMCMM_lastCloseTicket    = -1;  // Last processed order ticket (for tie-break)


### PR DESCRIPTION
## Summary
- remove the temporary step ratio state from the money-management templates
- round lots directly against the broker step so BaseLot scaling from Java is preserved

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbd98197c883279b02fac26c52a5fa