### PR TITLE
Fix DMCMM lot rounding to match Java logic

### DIFF
--- a/DecompositionMonteCarloMM_variables.tpl
+++ b/DecompositionMonteCarloMM_variables.tpl
@@ -12,6 +12,7 @@ int    DMCMM_consecWins           = 0;   // Consecutive win counter
 double DMCMM_cycleProfit          = 0.0; // Accumulated profit within the current cycle
 double DMCMM_curBet               = 0.0; // Current bet amount (lots)
 double DMCMM_lastExecutedBet      = 0.0; // Last theoretical bet used for closed order evaluation
+double DMCMM_stepRatio            = 1.0; // Scaling ratio between Java step and broker lot step
 int    DMCMM_processedOrdersCount = 0;   // Processed history orders counter
 datetime DMCMM_lastCloseTime      = 0;   // Last processed order close time
 int      DMCMM_lastCloseTicket    = -1;  // Last processed order ticket (for tie-break)


### PR DESCRIPTION
## Summary
- preserve the Java step resolution by tracking the ratio between StrategyQuant decimal precision and the broker's lot step
- adjust lot rounding to rescale back after broker step quantization so BaseLot scaling works as in Java

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cbdd245b588327909c1b99064c971e